### PR TITLE
Note that the Car Lease demonstration is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
-Car Lease Demo
+Car Lease Demo (Deprecated)
 =======
 
+This demonstration is now deprecated and cannot be deployed automatically.  The demonstration was created for the Blockchain Starter Plan service which uses Hyperledger Fabric version 0.6.1.  The Starter Plan service is in the process of being retired.  [An announcement](https://www.ibm.com/blogs/bluemix/2017/07/ibm-blockchain-starter-plan-retirement/) is available about the Starter Plan retirement. 
+
 ##Deploying the demo##
-To deploy to Bluemix simply use the button below then follow the instructions. This will generate the NodeJS server and the Blockchain service for you.
-
-[![Deploy to Bluemix](https://bluemix.net/deploy/button.png)](https://bluemix.net/deploy?repository=https://github.com/IBM-Blockchain/car-lease-demo.git)
-
 To deploy the demo locally follow the instructions [here](Documentation/Installation%20Guide.md#deploying-locally)
 
 ##Application overview##


### PR DESCRIPTION
Users have recently tried to use the "Deploy to Bluemix" button to automatically deploy the Car Lease demonstration and have observed that this process does not work.  This happened because the Blockchain Starter plan service is in the process of being retired.  As of August 17, new instances of the Starter Plan service (which uses Hyperledger Fabric version 0.6.1) could no longer be created.  The automatic deployment process attempts to create an instance of the Starter Plan service.  Since this is no longer possible, the "Deploy to Bluemix" button does not work.

I added a note to the README.md file explaining that the demonstration is deprecated and I removed the "Deploy to Bluemix" button.